### PR TITLE
Make wiki sidebar links display as blocks 

### DIFF
--- a/src/pages/wiki/wiki.scss
+++ b/src/pages/wiki/wiki.scss
@@ -72,6 +72,7 @@
       color: #BFC0C3;
       -webkit-transition: opacity .1s, color .1s;
       transition: opacity .1s, color .1s;
+      display: block;
     }
   }
 


### PR DESCRIPTION
Current behaviour on the wiki sidebar, with `a`s nested in `li`s, means that the `li` takes up the entire width of the parent but the link itself does not, requiring the text itself to be clicked on rather than its row in the list.
<img width="241" alt="image" src="https://user-images.githubusercontent.com/35287819/209479261-9bb50609-7b5f-42d1-a06b-0501363c0af6.png">

This PR alters the `a`s to take up the full width of the parent, making them easier to click.
<img width="251" alt="image" src="https://user-images.githubusercontent.com/35287819/209479289-ab02411e-e26f-413c-9c4f-a6f09448457c.png">
